### PR TITLE
.seq write torch compatibility

### DIFF
--- a/src/pulseqzero/__init__.py
+++ b/src/pulseqzero/__init__.py
@@ -2,6 +2,32 @@ from contextlib import contextmanager
 
 from .math import ceil, floor, round
 
+import torch
+from functools import wraps
+from types import SimpleNamespace
+
+def convert_tensor(x):
+    if isinstance(x, torch.Tensor):
+        x_np = x.detach().cpu().numpy()
+        if x_np.shape == () or (x_np.ndim == 1 and x_np.shape[0] == 1):
+            return x_np.item()
+        return x_np
+    elif isinstance(x, SimpleNamespace):
+        return SimpleNamespace(**{k: convert_tensor(v) for k, v in vars(x).items()})
+    elif isinstance(x, dict):
+        return {k: convert_tensor(v) for k, v in x.items()}
+    elif isinstance(x, (list, tuple)):
+        return type(x)(convert_tensor(v) for v in x)
+    else:
+        return x
+
+def torch_to_numpy(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        new_args = [convert_tensor(a) for a in args]
+        new_kwargs = {k: convert_tensor(v) for k, v in kwargs.items()}
+        return func(*new_args, **new_kwargs)
+    return wrapper
 
 class Impl:
     def __init__(self):
@@ -18,46 +44,54 @@ class Impl:
     def use_pypulseq(self):
         import pypulseq as pp
         self.mr0_mode = False
-        self.calc_SAR = pp.calc_SAR
-        self.Sequence = pp.Sequence
-        self.add_gradients = pp.add_gradients
-        self.align = pp.align
-        self.calc_duration = pp.calc_duration
-        self.calc_ramp = pp.calc_ramp
-        self.calc_rf_bandwidth = pp.calc_rf_bandwidth
-        self.calc_rf_center = pp.calc_rf_center
-        self.make_adc = pp.make_adc
-        self.make_adiabatic_pulse = pp.make_adiabatic_pulse
+        self.calc_SAR = torch_to_numpy(pp.calc_SAR)
+        class WrappedSequence(pp.Sequence):
+            def add_block(self, *args, **kwargs):
+                @torch_to_numpy
+                def inner(*a, **k):
+                    return super(WrappedSequence, self).add_block(*a, **k)
+                return inner(*args, **kwargs)
+            
+        self.Sequence = WrappedSequence
+        
+        self.add_gradients = torch_to_numpy(pp.add_gradients)
+        self.align = torch_to_numpy(pp.align)
+        self.calc_duration = torch_to_numpy(pp.calc_duration)
+        self.calc_ramp = torch_to_numpy(pp.calc_ramp)
+        self.calc_rf_bandwidth = torch_to_numpy(pp.calc_rf_bandwidth)
+        self.calc_rf_center = torch_to_numpy(pp.calc_rf_center)
+        self.make_adc = torch_to_numpy(pp.make_adc)
+        self.make_adiabatic_pulse = torch_to_numpy(pp.make_adiabatic_pulse)
         try:  # Fix for pypulseq 1.4.2 which doesn't re-export this
-            self.make_arbitrary_grad = pp.make_arbitrary_grad
+            self.make_arbitrary_grad = torch_to_numpy(pp.make_arbitrary_grad)
         except ImportError:
             from pypulseq.make_arbitrary_grad import make_arbitrary_grad
-            self.make_arbitrary_grad = make_arbitrary_grad
-        self.make_arbitrary_rf = pp.make_arbitrary_rf
-        self.make_block_pulse = pp.make_block_pulse
+            self.make_arbitrary_grad = torch_to_numpy(make_arbitrary_grad)
+        self.make_arbitrary_rf = torch_to_numpy(pp.make_arbitrary_rf)
+        self.make_block_pulse = torch_to_numpy(pp.make_block_pulse)
         # These were exported by pypulseq 1.4.2 but not by 1.4.2post1 anymore.
         # Since pulseq-zero has no equivalent anyways, we remove the imports.
         # self.sigpy_n_seq = pp.sigpy_n_seq
         # self.make_slr = pp.make_slr
         # self.make_sms = pp.make_sms
-        self.make_delay = pp.make_delay
-        self.make_digital_output_pulse = pp.make_digital_output_pulse
-        self.make_extended_trapezoid = pp.make_extended_trapezoid
-        self.make_extended_trapezoid_area = pp.make_extended_trapezoid_area
-        self.make_gauss_pulse = pp.make_gauss_pulse
-        self.make_label = pp.make_label
-        self.make_sinc_pulse = pp.make_sinc_pulse
-        self.make_trapezoid = pp.make_trapezoid
-        self.SigpyPulseOpts = pp.SigpyPulseOpts
-        self.make_trigger = pp.make_trigger
-        self.Opts = pp.Opts
-        self.points_to_waveform = pp.points_to_waveform
-        self.rotate = pp.rotate
-        self.scale_grad = pp.scale_grad
-        self.split_gradient = pp.split_gradient
-        self.split_gradient_at = pp.split_gradient_at
-        self.get_supported_labels = pp.get_supported_labels
-        self.traj_to_grad = pp.traj_to_grad
+        self.make_delay = torch_to_numpy(pp.make_delay)
+        self.make_digital_output_pulse = torch_to_numpy(pp.make_digital_output_pulse)
+        self.make_extended_trapezoid = torch_to_numpy(pp.make_extended_trapezoid)
+        self.make_extended_trapezoid_area = torch_to_numpy(pp.make_extended_trapezoid_area)
+        self.make_gauss_pulse = torch_to_numpy(pp.make_gauss_pulse)
+        self.make_label = torch_to_numpy(pp.make_label)
+        self.make_sinc_pulse = torch_to_numpy(pp.make_sinc_pulse)
+        self.make_trapezoid = torch_to_numpy(pp.make_trapezoid)
+        self.SigpyPulseOpts = torch_to_numpy(pp.SigpyPulseOpts)
+        self.make_trigger = torch_to_numpy(pp.make_trigger)
+        self.Opts = torch_to_numpy(pp.Opts)
+        self.points_to_waveform = torch_to_numpy(pp.points_to_waveform)
+        self.rotate = torch_to_numpy(pp.rotate)
+        self.scale_grad = torch_to_numpy(pp.scale_grad)
+        self.split_gradient = torch_to_numpy(pp.split_gradient)
+        self.split_gradient_at = torch_to_numpy(pp.split_gradient_at)
+        self.get_supported_labels = torch_to_numpy(pp.get_supported_labels)
+        self.traj_to_grad = torch_to_numpy(pp.traj_to_grad)
 
     def use_pulseqzero(self):
         from . import adapter as ad
@@ -112,3 +146,4 @@ def mr0_mode():
 
 def is_mr0_mode() -> bool:
     return pp_impl.mr0_mode
+

--- a/src/pulseqzero/__init__.py
+++ b/src/pulseqzero/__init__.py
@@ -52,6 +52,12 @@ class Impl:
                     return super(WrappedSequence, self).add_block(*a, **k)
                 return inner(*args, **kwargs)
             
+            def set_definition(self, *args, **kwargs):
+                @torch_to_numpy
+                def inner(*a, **k):
+                    return super(WrappedSequence, self).set_definition(*a, **k)
+                return inner(*args, **kwargs)
+            
         self.Sequence = WrappedSequence
         
         self.add_gradients = torch_to_numpy(pp.add_gradients)

--- a/src/pulseqzero/adapter/extended_trap_grad.py
+++ b/src/pulseqzero/adapter/extended_trap_grad.py
@@ -17,23 +17,28 @@ def make_extended_trapezoid_area(
     max_slew = system.max_slew * 0.99
     max_grad = system.max_grad * 0.99
     raster_time = system.grad_raster_time
-
+    
     
     def requires_grad(x):
         return torch.as_tensor(x).requires_grad
     
     if requires_grad(area):
-        raise ValueError(f"NOT YET DIFFERENTIABLE: make_extended_trapezoid_area() area parameter has requires_grads=True. File an issue if you need this functionality.")
+        raise ValueError("NOT YET DIFFERENTIABLE: make_extended_trapezoid_area() area parameter has requires_grads=True. File an issue if you need this functionality.")
     if requires_grad(grad_start):
-        raise ValueError(f"NOT YET DIFFERENTIABLE: make_extended_trapezoid_area() grad_start parameter has requires_grads=True. File an issue if you need this functionality.")
+        raise ValueError("NOT YET DIFFERENTIABLE: make_extended_trapezoid_area() grad_start parameter has requires_grads=True. File an issue if you need this functionality.")
     if requires_grad(grad_end):
-        raise ValueError(f"NOT YET DIFFERENTIABLE: make_extended_trapezoid_area() grad_end parameter has requires_grads=True. File an issue if you need this functionality.")
+        raise ValueError("NOT YET DIFFERENTIABLE: make_extended_trapezoid_area() grad_end parameter has requires_grads=True. File an issue if you need this functionality.")
+    
+    # Convert inputs to tensors
+    area = torch.as_tensor(area, dtype=torch.float64)
+    grad_start = torch.as_tensor(grad_start, dtype=torch.float64)
+    grad_end = torch.as_tensor(grad_end, dtype=torch.float64)
+    
+    def _to_raster(time):
+        return torch.ceil(time / raster_time) * raster_time
 
-    def _to_raster(time: float) -> float:
-        return np.ceil(time / raster_time) * raster_time
-
-    def _calc_ramp_time(grad_1: float, grad_2: float) -> float:
-        return _to_raster(abs(grad_1 - grad_2) / max_slew)
+    def _calc_ramp_time(grad_1, grad_2):
+        return _to_raster(torch.abs(grad_1 - grad_2) / max_slew)
     
     def _find_solution(duration: int):
         """Find extended trapezoid gradient waveform for given duration.
@@ -58,13 +63,13 @@ def make_extended_trapezoid_area(
         # Analytically calculate calculate the point where:
         #   grad_start + ramp_up_time * max_slew == grad_end + ramp_down_time * max_slew
         ramp_up_time = (duration * max_slew * raster_time - grad_start + grad_end) / (2 * max_slew * raster_time)
-        ramp_up_time = round(ramp_up_time)
+        ramp_up_time = torch.round(ramp_up_time)
 
         # Check if gradient amplitude exceeds max_grad, if so, adjust ramp
         # times for a trapezoidal gradient with maximum slew rate.
         if grad_start + ramp_up_time * max_slew * raster_time > max_grad:
-            ramp_up_time = round(_calc_ramp_time(grad_start, max_grad) / raster_time)
-            ramp_down_time = round(_calc_ramp_time(grad_end, max_grad) / raster_time)
+            ramp_up_time = torch.round(_calc_ramp_time(grad_start, max_grad) / raster_time)
+            ramp_down_time = torch.round(_calc_ramp_time(grad_end, max_grad) / raster_time)
         else:
             ramp_down_time = duration - ramp_up_time
 
@@ -76,13 +81,13 @@ def make_extended_trapezoid_area(
         # Analytically calculate calculate the point where:
         #   grad_start - ramp_up_time * max_slew == grad_end - ramp_down_time * max_slew
         ramp_up_time = (duration * max_slew * raster_time + grad_start - grad_end) / (2 * max_slew * raster_time)
-        ramp_up_time = round(ramp_up_time)
+        ramp_up_time = torch.round(ramp_up_time)
 
         # Check if gradient amplitude exceeds -max_grad, if so, adjust ramp
         # times for a trapezoidal gradient with maximum slew rate.
         if grad_start - ramp_up_time * max_slew * raster_time < -max_grad:
-            ramp_up_time = round(_calc_ramp_time(grad_start, -max_grad) / raster_time)
-            ramp_down_time = round(_calc_ramp_time(grad_end, -max_grad) / raster_time)
+            ramp_up_time = torch.round(_calc_ramp_time(grad_start, -max_grad) / raster_time)
+            ramp_down_time = torch.round(_calc_ramp_time(grad_end, -max_grad) / raster_time)
         else:
             ramp_down_time = duration - ramp_up_time
 
@@ -98,8 +103,8 @@ def make_extended_trapezoid_area(
             ramp_up_times.append(ramp_up_time)
             ramp_down_times.append(duration - ramp_up_time)
 
-        time_ramp_up = np.array(ramp_up_times)
-        time_ramp_down = np.array(ramp_down_times)
+        time_ramp_up = torch.tensor(ramp_up_times)
+        time_ramp_down = torch.tensor(ramp_down_times)
 
         # Calculate corresponding flat times
         flat_time = duration - time_ramp_up - time_ramp_down
@@ -116,40 +121,40 @@ def make_extended_trapezoid_area(
         )
 
         # Calculate slew rates for given timings
-        slew_rate1 = abs(grad_start - grad_amp) / (time_ramp_up * raster_time)
-        slew_rate2 = abs(grad_end - grad_amp) / (time_ramp_down * raster_time)
+        slew_rate1 = torch.abs(grad_start - grad_amp) / (time_ramp_up * raster_time)
+        slew_rate2 = torch.abs(grad_end - grad_amp) / (time_ramp_down * raster_time)
 
         # Filter solutions that satisfy max_grad and max_slew constraints
         valid_indices = (
-            (abs(grad_amp) <= max_grad + 1e-8) & (slew_rate1 <= max_slew + 1e-8) & (slew_rate2 <= max_slew + 1e-8)
+            (torch.abs(grad_amp) <= max_grad + 1e-8) & (slew_rate1 <= max_slew + 1e-8) & (slew_rate2 <= max_slew + 1e-8)
         )
-        solutions = np.flatnonzero(valid_indices)
+        solutions = torch.nonzero(valid_indices, as_tuple=False).flatten()
 
         # Check if any valid solutions were found
         if solutions.shape[0] == 0:
             return None
 
         # Find solution with lowest slew rate and return it
-        ind = np.argmin(slew_rate1[valid_indices] + slew_rate2[valid_indices])
+        ind = torch.argmin(slew_rate1[valid_indices] + slew_rate2[valid_indices])
         ind = solutions[ind]
         return (int(time_ramp_up[ind]), int(flat_time[ind]), int(time_ramp_down[ind]), float(grad_amp[ind]))
 
-    min_duration = max(round(_calc_ramp_time(grad_end, grad_start) / raster_time), 2)
-    max_duration = max(
-        round(_calc_ramp_time(0, grad_start) / raster_time),
-        round(_calc_ramp_time(0, grad_end) / raster_time),
-        min_duration,
+    min_duration = torch.max(torch.tensor([torch.round(_calc_ramp_time(grad_end, grad_start) / raster_time), 2]))
+    max_duration = torch.max(torch.tensor([
+        torch.round(_calc_ramp_time(0, grad_start) / raster_time),
+        torch.round(_calc_ramp_time(0, grad_end) / raster_time),
+        min_duration])
     )
 
     solution = None
-    for duration in range(min_duration, max_duration + 1):
+    for duration in range(min_duration.int(), max_duration.int() + 1):
         solution = _find_solution(duration)
         if solution:
             break
     if not solution:
         while not solution:
             max_duration *= 2
-            solution = _find_solution(max_duration)
+            solution = _find_solution(max_duration.int())
 
         def binary_search(fun, lower_limit, upper_limit):
             if lower_limit == upper_limit - 1:
@@ -162,36 +167,34 @@ def make_extended_trapezoid_area(
             else:
                 return binary_search(fun, test_value, upper_limit)
 
-        solution = binary_search(_find_solution, max_duration // 2, max_duration)
+        solution = binary_search(_find_solution, max_duration.int() // 2, max_duration.int())
 
     # Get timing and gradient amplitude from solution
-    time_ramp_up = solution[0] * raster_time
-    flat_time = solution[1] * raster_time
-    time_ramp_down = solution[2] * raster_time
-    grad_amp = solution[3]
+    time_ramp_up = torch.tensor(solution[0] * raster_time)
+    flat_time = torch.tensor(solution[1] * raster_time)
+    time_ramp_down = torch.tensor(solution[2] * raster_time)
+    grad_amp = torch.tensor(solution[3])
 
     # Create extended trapezoid
-    def cumsum(*args):
-        return np.cumsum(args).tolist()
+    def cumsum(args):
+        return torch.cumsum(args, dim=0)
 
     if flat_time > 0:
-        times = cumsum(0, time_ramp_up, flat_time, time_ramp_down)
-        amplitudes = np.array([grad_start, grad_amp, grad_amp, grad_end])
+        times = cumsum(torch.tensor([0, time_ramp_up, flat_time, time_ramp_down]))
+        amplitudes = torch.tensor([grad_start, grad_amp, grad_amp, grad_end])
     else:
-        print(time_ramp_up)
-        print(time_ramp_down)
-        times = cumsum(0, time_ramp_up, time_ramp_down)
-        amplitudes = np.array([grad_start, grad_amp, grad_end])
+        times = cumsum(torch.tensor([0, time_ramp_up, time_ramp_down]))
+        amplitudes = torch.tensor([grad_start, grad_amp, grad_end])
 
     grad = make_extended_trapezoid(
         channel=channel,
         system=system,
-        times=torch.tensor(times),
-        amplitudes=torch.tensor(amplitudes)
+        times=times,
+        amplitudes=amplitudes
     )
 
 
-    if not abs(grad.area - area) < 1e-8:
+    if not torch.abs(grad.area - area) < 1e-8:
         raise ValueError(f'Could not find a solution for area={area}.')
 
-    return grad, np.array(times), amplitudes
+    return grad, times, amplitudes

--- a/src/pulseqzero/adapter/grads.py
+++ b/src/pulseqzero/adapter/grads.py
@@ -263,7 +263,7 @@ def add_gradients(
         raise ValueError("No gradients specified")
     if len(grads) == 1:
         return deepcopy(grads[0])
-    
+
     channel = grads[0].channel
     if any(g.channel != channel for g in grads):
         raise ValueError("Cannot add gradients on different channels")
@@ -314,30 +314,51 @@ def add_gradients(
         attr = check_req_grad(grad)
         if attr is not None:
             raise ValueError(f"add_gradients() is not yet differentiable, but {attr} of {grad} has requires_grad=True. File an issue if you need this functionality.")
-    
+            
     def points_to_waveform(amplitudes, grad_raster_time, times):
-        amplitudes = np.asarray(amplitudes)
-        times = np.asarray(times)
+        amplitudes = torch.as_tensor(amplitudes, dtype=torch.float64)
+        times = torch.as_tensor(times, dtype=torch.float64)
 
-        if amplitudes.size == 0:
-            return np.array([0])
+        if amplitudes.numel() == 0:
+            return torch.tensor([0.0], dtype=torch.float64)
 
-        grd = (
-            np.arange(
-                start=round(np.min(times) / grad_raster_time),
-                stop=round(np.max(times) / grad_raster_time),
-            )
-            * grad_raster_time
-        )
-        waveform = np.interp(x=grd + grad_raster_time / 2, xp=times, fp=amplitudes)
+        start_val = round((torch.min(times) / grad_raster_time).item())
+        stop_val = round((torch.max(times) / grad_raster_time).item())
+        grd = torch.arange(start_val, stop_val, dtype=torch.float64) * grad_raster_time
+
+        # PyTorch equivalent of np.interp
+        x_vals = grd + grad_raster_time / 2
+        waveform = torch.zeros_like(x_vals)
+        
+        for i, x in enumerate(x_vals):
+            # Find the interpolation indices
+            idx = torch.searchsorted(times, x, right=False)
+            if len(times) == 0:
+                waveform[i] = 0.0
+            elif idx == 0:
+                if x <= times[0]:
+                    waveform[i] = amplitudes[0]
+                else:
+                    waveform[i] = amplitudes[0]
+            elif idx >= len(times):
+                waveform[i] = amplitudes[-1]
+            else:
+                # Linear interpolation
+                t0, t1 = times[idx-1], times[idx]
+                a0, a1 = amplitudes[idx-1], amplitudes[idx]
+                if t1 != t0:
+                    alpha = (x - t0) / (t1 - t0)
+                    waveform[i] = a0 + alpha * (a1 - a0)
+                else:
+                    waveform[i] = a0
 
         return waveform
 
     # - copy of pulseq code
     import numpy as np
     eps = 1e-9
-    def cumsum(*args):
-        return np.cumsum(args).tolist()
+    def cumsum(args):
+        return torch.cumsum(args)
 
     # Find out the general delay of all gradients and other statistics
     delays, firsts, lasts, durs, is_trap, is_arb = [], [], [], [], [], []
@@ -354,10 +375,12 @@ def add_gradients(
             is_arb.append(False)
         else:
             tt_rast = grads[ii].tt / system.grad_raster_time - 0.5
-            is_arb.append(np.all(np.abs(tt_rast - np.arange(len(tt_rast)))) < eps)
+            is_arb.append(torch.all(torch.abs(tt_rast - torch.arange(len(tt_rast)))) < eps)
+    is_arb = torch.as_tensor(is_arb)
+    is_trap = torch.as_tensor(is_trap)
 
     # Check if we only have arbitrary grads on irregular time samplings, optionally mixed with trapezoids
-    if np.all(np.logical_or(is_trap, np.logical_not(is_arb))):
+    if torch.all(torch.logical_or(is_trap, torch.logical_not(is_arb))):
         # Keep shapes still rather simple
         times = []
         for ii in range(len(grads)):
@@ -369,55 +392,76 @@ def add_gradients(
             else:
                 times.extend(g.delay + g.tt)
 
-        times = np.unique(times)
+        times = torch.unique(torch.tensor(times))
         dt = times[1:] - times[:-1]
-        ieps = np.flatnonzero(dt < eps)
-        if np.any(ieps):
-            dtx = np.array([times[0], *dt])
+        ieps = torch.nonzero(dt < eps, as_tuple=False).flatten()
+        if torch.any(ieps):
+            dtx = torch.tensor([times[0], *dt])
             dtx[ieps] = (
                 dtx[ieps] + dtx[ieps + 1]
             )  # Assumes that no more than two too similar values can occur
-            dtx = np.delete(dtx, ieps + 1)
-            times = np.cumsum(dtx)
+            dtx = torch.delete(dtx, ieps + 1)
+            times = torch.cumsum(dtx)
 
-        amplitudes = np.zeros_like(times)
+        amplitudes = torch.zeros_like(times)
         for ii in range(len(grads)):
             g = grads[ii]
             if isinstance(g, TrapGrad):
                 if g.flat_time > 0:  # Trapezoid or triangle
-                    tt = list(cumsum(g.delay, g.rise_time, g.flat_time, g.fall_time))
-                    waveform = [0, g.amplitude, g.amplitude, 0]
+                    tt = cumsum(g.delay, g.rise_time, g.flat_time, g.fall_time)
+                    waveform = torch.tensor([0, g.amplitude, g.amplitude, 0], dtype=torch.float64)
                 else:
-                    tt = list(cumsum(g.delay, g.rise_time, g.fall_time))
-                    waveform = [0, g.amplitude, 0]
+                    tt = cumsum(g.delay, g.rise_time, g.fall_time)
+                    waveform = torch.tensor([0, g.amplitude, 0], dtype=torch.float64)
             else:
                 tt = g.delay + g.tt
                 waveform = g.waveform
 
             # Fix rounding for the first and last time points
-            i_min = np.argmin(np.abs(tt[0] - times))
-            t_min = (np.abs(tt[0] - times))[i_min]
+            i_min = torch.argmin(torch.abs(tt[0] - times))
+            t_min = torch.abs(tt[0] - times)[i_min]
             if t_min < eps:
                 tt[0] = times[i_min]
-            i_min = np.argmin(np.abs(tt[-1] - times))
-            t_min = (np.abs(tt[-1] - times))[i_min]
+            i_min = torch.argmin(torch.abs(tt[-1] - times))
+            t_min = torch.abs(tt[-1] - times)[i_min]
             if t_min < eps:
                 tt[-1] = times[i_min]
 
             if abs(waveform[0]) > eps and tt[0] > eps:
                 tt[0] += eps
 
-            amplitudes += np.interp(xp=tt, fp=waveform, x=times, left=0, right=0)
+            # PyTorch equivalent of np.interp with left=0, right=0
+            interp_values = torch.zeros_like(times)
+            for i, x in enumerate(times):
+                idx = torch.searchsorted(tt, x)
+                if idx == 0:
+                    if x <= tt[0]:
+                        interp_values[i] = 0.0  # left=0
+                    else:
+                        interp_values[i] = waveform[0]
+                elif idx >= len(tt):
+                    if x >= tt[-1]:
+                        interp_values[i] = 0.0  # right=0
+                    else:
+                        interp_values[i] = waveform[-1]
+                else:
+                    # Linear interpolation
+                    t0, t1 = tt[idx-1], tt[idx]
+                    w0, w1 = waveform[idx-1], waveform[idx]
+                    alpha = (x - t0) / (t1 - t0)
+                    interp_values[i] = w0 + alpha * (w1 - w0)
+            
+            amplitudes += interp_values
 
         grad = make_extended_trapezoid(
             channel=channel, amplitudes=amplitudes, times=times, system=system
         )
         return grad
     
-    # Convert to numpy.ndarray for fancy-indexing later on
-    firsts, lasts = np.array(firsts), np.array(lasts)
-    common_delay = np.min(delays)
-    durs = np.array(durs)
+    # Convert to torch tensors for indexing later on
+    firsts, lasts = torch.tensor(firsts, dtype=torch.float64), torch.tensor(lasts, dtype=torch.float64)
+    common_delay = min(delays)
+    durs = torch.tensor(durs, dtype=torch.float64)
 
     # Convert everything to a regularly-sampled waveform
     waveforms = dict()
@@ -435,7 +479,7 @@ def add_gradients(
                 )
         elif isinstance(g, TrapGrad):
             if g.flat_time > 0:  # Triangle or trapezoid
-                times = np.array(
+                times = torch.tensor(
                     [
                         g.delay - common_delay,
                         g.delay - common_delay + g.rise_time,
@@ -445,18 +489,18 @@ def add_gradients(
                         + g.rise_time
                         + g.flat_time
                         + g.fall_time,
-                    ]
+                    ], dtype=torch.float64
                 )
-                amplitudes = np.array([0, g.amplitude, g.amplitude, 0])
+                amplitudes = torch.tensor([0, g.amplitude, g.amplitude, 0], dtype=torch.float64)
             else:
-                times = np.array(
+                times = torch.tensor(
                     [
                         g.delay - common_delay,
                         g.delay - common_delay + g.rise_time,
                         g.delay - common_delay + g.rise_time + g.fall_time,
-                    ]
+                    ], dtype=torch.float64
                 )
-                amplitudes = np.array([0, g.amplitude, 0])
+                amplitudes = torch.tensor([0, g.amplitude, 0], dtype=torch.float64)
             waveforms[ii] = points_to_waveform(
                 amplitudes=amplitudes,
                 times=times,
@@ -466,18 +510,18 @@ def add_gradients(
             raise ValueError("Unknown gradient type")
 
         if g.delay - common_delay > 0:
-            # Stop for numpy.arange is not g.delay - common_delay - system.grad_raster_time like in Matlab
-            # so as to include the endpoint
-            t_delay = np.arange(0, g.delay - common_delay, step=system.grad_raster_time)
-            waveforms[ii] = np.concatenate(([t_delay], waveforms[ii]))
+            # Create delay samples using torch.arange
+            t_delay = torch.arange(0, g.delay - common_delay, step=system.grad_raster_time, dtype=torch.float64)
+            waveforms[ii] = torch.cat([torch.zeros_like(t_delay), waveforms[ii]])
 
         num_points = len(waveforms[ii])
         max_length = max(num_points, max_length)
 
-    w = np.zeros(max_length)
+    w = torch.zeros(max_length, dtype=torch.float64)
     for ii in range(len(grads)):
-        wt = np.zeros(max_length)
-        wt[0 : len(waveforms[ii])] = waveforms[ii]
+        wt = torch.zeros(max_length, dtype=torch.float64)
+        waveform_len = len(waveforms[ii])
+        wt[:waveform_len] = waveforms[ii]
         w += wt
 
     grad = make_arbitrary_grad(
@@ -491,7 +535,8 @@ def add_gradients(
     # Fix the first and the last values
     # First is defined by the sum of firsts with the minimal delay (common_delay)
     # Last is defined by the sum of lasts with the maximum duration (total_duration == durs.max())
-    grad.first = np.sum(firsts[np.array(delays) == common_delay])
-    grad.last = np.sum(lasts[durs == durs.max()])
+    delays_tensor = torch.tensor(delays, dtype=torch.float64)
+    grad.first = torch.sum(firsts[delays_tensor == common_delay])
+    grad.last = torch.sum(lasts[durs == torch.max(durs)])
 
     return grad

--- a/src/pulseqzero/adapter/seq_convert.py
+++ b/src/pulseqzero/adapter/seq_convert.py
@@ -6,6 +6,13 @@ from ..adapter.adc import Adc
 from ..adapter.delay import Delay
 from ..adapter.grads import TrapGrad, FreeGrad
 
+def convert_tensors_to_float32(obj):
+    if hasattr(obj, '__dataclass_fields__'):
+        for field_name in obj.__dataclass_fields__:
+            value = getattr(obj, field_name)
+            if isinstance(value, torch.Tensor) and value.dtype == torch.float64:
+                setattr(obj, field_name, value.to(dtype=torch.float32))
+    return obj
 
 def convert(pp0) -> mr0.Sequence:
     seq = []
@@ -18,6 +25,7 @@ def convert(pp0) -> mr0.Sequence:
         grad_y = None
         grad_z = None
         for ev in block:
+            ev = convert_tensors_to_float32(ev)
             if isinstance(ev, Delay):
                 assert delay is None
                 delay = ev


### PR DESCRIPTION
This version is compartible with seq.write.
- It converts all torch.tensors zu numpy.arrays for seq.write
- It changes all tensors from float64 to float32 when calling `pulseqzero.mr0_mode`