### PR TITLE
Bugfix arbitrarygrad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to pulseq-zero are recorded in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1]
+
+### Fixed
+
+- **Arbitrary gradients: endpoints now included when integrating.**
+  `seq_convert.integrate` previously integrated only over the internal
+  `grad.tt` / `grad.waveform` samples of an `ArbitraryGrad`, silently
+  dropping the `first` and `last` boundary samples. The waveform is now
+  padded with `first` at `t=0` and `last` at `t=shape_dur` before
+  integration, so the ramps into and out of the free waveform are
+  accounted for.
+- **`parse_pulse`: sub-pulse centring matches PyPulseq's RF timing.**
+  The effective time of each MRzero sub-pulse is now centred within the
+  RF shape itself (`rf.delay + (i + 0.5) * step`), rather than being
+  derived from the midpoints of the integration windows used to bucket
+  the waveform. This changes (and corrects) the timing of ADC samples
+  during simulation to match PyPulseq's definition of RF timing.
+
 ## [1.0.0]
 
 The 1.0 release unifies pulseq-zero into a single, always-on facade. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pulseqzero"
-version = "1.0.0"
+version = "1.0.1"
 description = "Use PyPulseq for MRI sequence definitions in MR-zero"
 readme = "README.md"
 authors = [

--- a/src/pulseqzero/seq_convert.py
+++ b/src/pulseqzero/seq_convert.py
@@ -190,10 +190,22 @@ def parse_pulse(delay, rf, grad_x, grad_y, grad_z, samples: int) -> list[TmpPuls
     # time points edges of the pulse buckets which are integrated over
     duration = calc_duration(delay, rf, grad_x, grad_y, grad_z)
     step = rf.shape_dur / samples
+
     # Adjusted to cover whole block
+    # Integration windows used to divide the RF waveform.
+    # The first and last windows include the regions before and after the
+    # RF waveform. integrate_pulse() evaluates the RF as zero there.
     t_rf = [0] + [rf.delay + step * i for i in range(1, samples)] + [duration]
+    
+    # Effective time of each instantaneous MRzero sub-pulse.
+    # These must be centred within the actual RF shape, without including
+    # RF dead time, RF delay, or ringdown in the centring operation.
+    pulse_times = [
+        rf.delay + (i + 0.5) * step
+        for i in range(samples)
+    ]
     # grads are integrated from one pulse center to the next
-    t_grad = [0] + [(t1 + t2) / 2 for t1, t2 in zip(t_rf[0:], t_rf[1:])] + [duration]
+    t_grad = [0] + pulse_times + [duration]
     
     # Alternate spoiler from one pulse center to next with pulse itself
     events: list[TmpPulse | TmpSpoiler] = []

--- a/src/pulseqzero/seq_convert.py
+++ b/src/pulseqzero/seq_convert.py
@@ -329,11 +329,28 @@ def integrate(grad, t):
         # https://www.desmos.com/calculator/j2vopzhb2z
 
         d = grad.delay
+
+        tt = torch.as_tensor(grad.tt)
+        waveform = torch.as_tensor(grad.waveform).reshape(-1)
+
+        if isinstance(grad, ArbitraryGrad):
+            tt = torch.cat((
+                torch.zeros(1, dtype=tt.dtype),
+                tt,
+                torch.as_tensor(grad.shape_dur, dtype=tt.dtype).reshape(1),
+            ))
+
+            waveform = torch.cat((
+                torch.as_tensor(grad.first, dtype=waveform.dtype).reshape(1),
+                waveform,
+                torch.as_tensor(grad.last, dtype=waveform.dtype).reshape(1),
+            ))
+
         # Start and end time point and amplitude of all line segments
-        t1 = d + torch.as_tensor(grad.tt[:-1])
-        t2 = d + torch.as_tensor(grad.tt[1:])
-        c1 = torch.as_tensor(grad.waveform[:-1])
-        c2 = torch.as_tensor(grad.waveform[1:])
+        t1 = d + tt[:-1]
+        t2 = d + tt[1:]
+        c1 = waveform[:-1]
+        c2 = waveform[1:]
 
         # This is how much of every segment contributes, clamped to [0, width]
         t_rel = torch.clamp(t - t1, 0 * t1, t2 - t1)

--- a/uv.lock
+++ b/uv.lock
@@ -285,37 +285,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1122,7 +1122,7 @@ wheels = [
 
 [[package]]
 name = "pulseqzero"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "mrzerocore" },


### PR DESCRIPTION
Hi all,
I've found an inconsistency between the k-space trajectories and the simulated signals in the demo code below. It simulates a simple constant arbitrary gradient once in pypulseq via .seq import and once in pulseq-zero via .to_mr0() 

<img width="989" height="390" alt="Image" src="https://github.com/user-attachments/assets/db744712-52fa-4e49-a1d0-755f21741277" />

as far as I see, there are two causes, which I've tried to fix here:
- arbitrary grad integration does not consider 'first' and 'last' samples
- parse_pulse defines effective RF pulses using intervals that span the
   entire block, including RF delay and ringdown, rather than at the
   centers of the actual RF shape 'buckets', which leads to a deviation of ADC sample timings

It fixes the demo below, but not sure if it may interfere with other things.

Cheers, Felix

---
minimal example:
```
import matplotlib.pyplot as plt
import MRzeroCore as mr0
import numpy as np
import pypulseq as pypp
import pulseqzero as p0


N = 10 # number of waveform samples
ros = 2 # readout oversampling factor
grad_raster = 10e-6
wave = np.ones(N)
# wave = np.concatenate([np.linspace(0,10,N//2), np.linspace(10,0,N//2)])


def make_sequence(pp):
    system = pp.Opts(
        max_grad=28, grad_unit="mT/m",
        max_slew=150, slew_unit="T/m/s",
        rf_ringdown_time=20e-6,
        rf_dead_time=100e-6,
        adc_dead_time=20e-6,
        grad_raster_time=grad_raster,
    )
    seq = pp.Sequence(system)

    rf, _, _ = pp.make_sinc_pulse(
        flip_angle=np.deg2rad(5),
        duration=1e-3,
        slice_thickness=5e-3,
        apodization=0.5,
        time_bw_product=4,
        system=system,
        return_gz=True,
    )

    adc = pp.make_adc(
        num_samples=N * ros,
        dwell=grad_raster / ros,
        system=system,
    )

    grad = pp.make_arbitrary_grad(
        channel="x",
        waveform=wave,
        delay=adc.delay,
        system=system,
    )

    seq.add_block(rf)
    seq.add_block(grad, adc)

    return seq


# Construct equivalent sequences in pypulseq and pusleqzero
seq_pp = make_sequence(pypp)
seq_p0 = make_sequence(p0)

signal_pp, k_mr0_pp = mr0.util.simulate(seq_pp)
signal_p0, k_mr0_p0 = mr0.util.simulate(seq_p0.to_mr0())

k_pp, *_ = seq_pp.calculate_kspace()
k_p0, *_ = seq_p0.to_pypulseq().calculate_kspace()

fig, ax = plt.subplots(1, 2, figsize=(10, 4))

ax[0].plot(k_mr0_pp[:, 0], ".-", label="PyPulseq → MRzero")
ax[0].plot(k_pp[0], ".-", label="PyPulseq")
ax[0].plot(k_mr0_p0[:, 0], ".-", label="Pulseq-zero → MRzero")
ax[0].plot(k_p0[0], ".-", label="Pulseq-zero → PyPulseq")
ax[0].set_title("ADC k-space")
ax[0].set_xlabel("ADC sample")
ax[0].set_ylabel(r"$k_x$ / m$^{-1}$")
ax[0].legend()

ax[1].plot(signal_pp.real, ".-", label="PyPulseq → MRzero")
ax[1].plot(signal_p0.real, ".-", label="Pulseq-zero → MRzero")
ax[1].set_title("Simulated signal")
ax[1].set_xlabel("ADC sample")
ax[1].set_ylabel("Real signal")
ax[1].legend()

fig.tight_layout()
plt.show()
```